### PR TITLE
Two more fixes...

### DIFF
--- a/qucs/qucs/dialogs/matchdialog.cpp
+++ b/qucs/qucs/dialogs/matchdialog.cpp
@@ -1329,7 +1329,7 @@ QString MatchDialog::calcDoubleStub(double r_real, double r_imag, double Z0,
                      .arg(d)
                      .arg(lstub1);
   if ((open_short) && (!BalancedStubs))
-    laddercode = QString("OL:%1#%2;TL:%1#%3;OL:%1#%4")
+    laddercode = QString("OL:%1#%2;TL:%1#%3;OL:%1#%4;")
                      .arg(Z0)
                      .arg(lstub2)
                      .arg(d)
@@ -1341,7 +1341,7 @@ QString MatchDialog::calcDoubleStub(double r_real, double r_imag, double Z0,
                      .arg(d)
                      .arg(lstub1);
   if ((!open_short) && (!BalancedStubs))
-    laddercode = QString("SL:%1#%2;TL:%1#%3;SL:%1#%4")
+    laddercode = QString("SL:%1#%2;TL:%1#%3;SL:%1#%4;")
                      .arg(Z0)
                      .arg(lstub2)
                      .arg(d)

--- a/qucs/qucs/dialogs/matchdialog.cpp
+++ b/qucs/qucs/dialogs/matchdialog.cpp
@@ -1995,7 +1995,6 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
                            .arg(x_pos)
                            .arg(QChar(0x2126))
                            .arg(misc::num2str(Freq, 3, "Hz"))
-                           .arg(Freq * 1e-9)
                            .arg(RL);
       } else if ((RL < 1e-3) && (XL > 1e-3)) // L
       {
@@ -2011,7 +2010,6 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
                 .arg(x_pos)
                 .arg(QChar(0x2126))
                 .arg(misc::num2str(Freq, 3, "Hz"))
-                .arg(Freq * 1e-9)
                 .arg(XL);
       } else if ((RL < 1e-3) && (XL < -1e-3)) // C
       {


### PR DESCRIPTION
[EDIT]

* ccbac55 Fixes the missing spar block at double stub synthesis
* f42b73f  The value of the load impedance was wrong when selecting a purely resistive/inductive load. It seems that this bug was caused by an old line of code hanging there...

I'm thinking that it may be good to leave the window opened after synthesizing the network (currently, it is automatically closed)







